### PR TITLE
add DataBaseDesign to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Things you may want to cover:
 |email|string|null: false|
 |password|string|null: false|
 ### Association
-- has_many :groups
+- has_many :groups_users
+- has_many :groups, through: :groups_users
 - has_many :posts
 
 
@@ -50,7 +51,8 @@ Things you may want to cover:
 |groupname|string|null: false|
 |post_id|integer|null: false, foreign_key: true|
 ### Association
-- has_many :user
+- has_many :groups_users
+- has_many :user, through: :groups_users
 - has_many :posts
 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|username|string|null: false|
+|name|string|null: false, index: true|
 |email|string|null: false|
 |password|string|null: false|
 ### Association

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false|
+|group|string|null: false|
 |post_id|integer|null: false, foreign_key: true|
 ### Association
 - has_many :groups_users

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Things you may want to cover:
 |------|----|-------|
 |image|text||
 |text|text||
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -22,3 +22,55 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|username|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+### Association
+- has_many :groups
+- has_many :posts
+
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+|post_id|integer|null: false, foreign_key: true|
+### Association
+- has_many :user
+- has_many :posts
+
+
+## groups_postsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_id|integer|null: false, foreign_key: true|
+|post_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :post
+
+
+## postsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|image|text||
+|text|text||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -55,16 +55,6 @@ Things you may want to cover:
 - has_many :posts
 
 
-## groups_postsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|group_id|integer|null: false, foreign_key: true|
-|post_id|integer|null: false, foreign_key: true|
-### Association
-- belongs_to :group
-- belongs_to :post
-
-
 ## postsテーブル
 |Column|Type|Options|
 |------|----|-------|

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Things you may want to cover:
 ## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |group|string|null: false|
-|post_id|integer|null: false, foreign_key: true|
 ### Association
 - has_many :groups_users
 - has_many :user, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Things you may want to cover:
 |group|string|null: false|
 ### Association
 - has_many :groups_users
-- has_many :user, through: :groups_users
+- has_many :users, through: :groups_users
 - has_many :posts
 
 


### PR DESCRIPTION
#what
README.mdにchat-spaceに必要なデータベース設計を下記の項目を記載。
usersテーブル
groups_usersテーブル
groupsテーブル
groups_postsテーブル
postsテーブル

#why
chat-space作成に必要なデータ設計を把握するため。